### PR TITLE
Permit some config_entry options to be unset without throwing

### DIFF
--- a/custom_components/cync_lights/light.py
+++ b/custom_components/cync_lights/light.py
@@ -19,8 +19,10 @@ async def async_setup_entry(
     hub = hass.data[DOMAIN][config_entry.entry_id]
 
     new_devices = []
+    config_rooms = "rooms" in config_entry.options and config_entry.options["rooms"] or {}
+    config_subgroups = "subgroups" in config_entry.options and config_entry.options["subgroups"] or {}
     for room in hub.cync_rooms:
-        if not hub.cync_rooms[room]._update_callback and (room in config_entry.options["rooms"] or room in config_entry.options["subgroups"]):
+        if not hub.cync_rooms[room]._update_callback and (room in config_rooms or room in config_subgroups):
             new_devices.append(CyncRoomEntity(hub.cync_rooms[room]))
 
     for switch_id in hub.cync_switches:


### PR DESCRIPTION
Not sure what changed, but when I updated my installation to the [latest commit](https://github.com/nikshriv/cync_lights/commit/38224b9c379a28ffaf4ad8143b72690b33c490d3), it started throwing:

```
2023-05-02 08:09:00.843 ERROR (MainThread) [homeassistant.components.light] Error while setting up cync_lights platform for light
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 304, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/cync_lights/light.py", line 25, in async_setup_entry
    if not hub.cync_rooms[room]._update_callback and (room in config_entry.options["rooms"] or room in config_entry.options["subgroups"]):
KeyError: 'subgroups'
```

It seems safe to assume that an unset value is the same as an empty value, so this PR does that.