### PR TITLE
Switch to using kelvins for color temperature

### DIFF
--- a/custom_components/cync_lights/cync_hub.py
+++ b/custom_components/cync_lights/cync_hub.py
@@ -55,7 +55,7 @@ class CyncHub:
         self.pending_commands = {}
         [room.initialize() for room in self.cync_rooms.values() if room.is_subgroup]
         [room.initialize() for room in self.cync_rooms.values() if not room.is_subgroup]
-        
+
     def start_tcp_client(self):
         self.thread = threading.Thread(target=self._start_tcp_client,daemon=True)
         self.thread.start()
@@ -105,7 +105,7 @@ class CyncHub:
                         except Exception as e:
                             _LOGGER.error(str(type(e).__name__) + ": " + str(e))
                     for task in pending:
-                        task.cancel()                    
+                        task.cancel()
                     if not self.shutting_down:
                         _LOGGER.error("Connection to Cync server reset, restarting in 15 seconds")
                         await asyncio.sleep(15)
@@ -145,7 +145,7 @@ class CyncHub:
                                 state = int(packet[27]) > 0
                                 brightness = int(packet[28]) if state else 0
                                 if deviceID in self.cync_switches:
-                                    self.cync_switches[deviceID].update_switch(state,brightness,self.cync_switches[deviceID].color_temp,self.cync_switches[deviceID].rgb)
+                                    self.cync_switches[deviceID].update_switch(state,brightness,self.cync_switches[deviceID].color_temp_kelvin,self.cync_switches[deviceID].rgb)
                             elif packet_length >= 25 and int(packet[13]) == 84:
                                 #parse motion and ambient light sensor packet
                                 deviceID = self.home_devices[home_id][int(packet[16])]
@@ -169,7 +169,7 @@ class CyncHub:
                                                 device_id = self.home_devices[home_id][(i+1)*256 + int(packet[0])]
                                                 state = int((int(packet[12]) >> i) & int(packet[8])) > 0
                                                 brightness = 100 if state else 0
-                                                self.cync_switches[device_id].update_switch(state, brightness, self.cync_switches[device_id].color_temp, self.cync_switches[device_id].rgb)
+                                                self.cync_switches[device_id].update_switch(state,brightness,self.cync_switches[device_id].color_temp_kelvin,self.cync_switches[device_id].rgb)
                                         else:
                                             state = int(packet[8]) > 0
                                             brightness = int(packet[12]) if state else 0
@@ -186,7 +186,7 @@ class CyncHub:
                                 state = int(packet[27]) > 0
                                 brightness = int(packet[28]) if state else 0
                                 if deviceID in self.cync_switches:
-                                    self.cync_switches[deviceID].update_switch(state,brightness,self.cync_switches[deviceID].color_temp,self.cync_switches[deviceID].rgb)
+                                    self.cync_switches[deviceID].update_switch(state,brightness,self.cync_switches[deviceID].color_temp_kelvin,self.cync_switches[deviceID].rgb)
                             elif packet_length >= 25 and int(packet[13]) == 84:
                                 #parse motion and ambient light sensor packet
                                 deviceID = self.home_devices[home_id][int(packet[16])]
@@ -210,7 +210,7 @@ class CyncHub:
                                                 device_id = self.home_devices[home_id][(i+1)*256 + int(packet[3])]
                                                 state = int((int(packet[5]) >> i) & int(packet[4])) > 0
                                                 brightness = 100 if state else 0
-                                                self.cync_switches[device_id].update_switch(state, brightness, self.cync_switches[device_id].color_temp, self.cync_switches[device_id].rgb)
+                                                self.cync_switches[device_id].update_switch(state,brightness,self.cync_switches[device_id].color_temp_kelvin,self.cync_switches[device_id].rgb)
                                         else:
                                             state = int(packet[4]) > 0
                                             brightness = int(packet[5]) if state else 0
@@ -249,7 +249,7 @@ class CyncHub:
                     for dev in self.cync_switches.values():
                         dev.update_controllers()
                     for room in self.cync_rooms.values():
-                        room.update_controllers() 
+                        room.update_controllers()
 
     async def _update_connected_devices(self):
         while not self.shutting_down:
@@ -267,7 +267,7 @@ class CyncHub:
                         self.loop.call_soon_threadsafe(self.send_request, ping)
                         await asyncio.sleep(0.15)
                 await asyncio.sleep(2)
-                attempts += 1            
+                attempts += 1
             for dev in self.cync_switches.values():
                 dev.update_controllers()
             for room in self.cync_rooms.values():
@@ -291,13 +291,13 @@ class CyncHub:
             dev.publish_update()
         for room in self.cync_rooms.values():
             dev.publish_update()
-            
+
     def send_request(self,request):
         async def send():
             self.writer.write(request)
             await self.writer.drain()
         self.loop.create_task(send())
-        
+
     def combo_control(self,state,brightness,color_tone,rgb,switch_id,mesh_id,seq):
         combo_request = bytes.fromhex('7300000022') + int(switch_id).to_bytes(4,'big') + int(seq).to_bytes(2,'big') + bytes.fromhex('007e00000000f8f010000000000000') + mesh_id + bytes.fromhex('f00000') + (1 if state else 0).to_bytes(1,'big')  + brightness.to_bytes(1,'big') + color_tone.to_bytes(1,'big') + rgb[0].to_bytes(1,'big') + rgb[1].to_bytes(1,'big') + rgb[2].to_bytes(1,'big') + ((496 + int(mesh_id[0]) + int(mesh_id[1]) + (1 if state else 0) + brightness + color_tone + sum(rgb))%256).to_bytes(1,'big') + bytes.fromhex('7e')
         self.loop.call_soon_threadsafe(self.send_request,combo_request)
@@ -334,7 +334,7 @@ class CyncRoom:
         self.mesh_id = int(room_info.get('mesh_id',0)).to_bytes(2,'little')
         self.power_state = False
         self.brightness = 0
-        self.color_temp = 0
+        self.color_temp_kelvin = 0
         self.rgb = {'r':0, 'g':0, 'b':0, 'active': False}
         self.switches = room_info.get('switches',[])
         self.subgroups = room_info.get('subgroups',[])
@@ -363,7 +363,7 @@ class CyncRoom:
         self.switches_support_rgb = [device_id for device_id in self.switches if self.hub.cync_switches[device_id].support_rgb]
         self.groups_support_brightness = [room_id for room_id in self.subgroups if self.hub.cync_rooms[room_id].support_brightness]
         self.groups_support_color_temp = [room_id for room_id in self.subgroups if self.hub.cync_rooms[room_id].support_color_temp]
-        self.groups_support_rgb = [room_id for room_id in self.subgroups if self.hub.cync_rooms[room_id].support_rgb] 
+        self.groups_support_rgb = [room_id for room_id in self.subgroups if self.hub.cync_rooms[room_id].support_rgb]
         self.support_brightness = (len(self.switches_support_brightness) + len(self.groups_support_brightness)) > 0
         self.support_color_temp = (len(self.switches_support_color_temp) + len(self.groups_support_color_temp)) > 0
         self.support_rgb = (len(self.switches_support_rgb) + len(self.groups_support_rgb)) > 0
@@ -387,14 +387,14 @@ class CyncRoom:
         self._update_parent_room = parent_updater
 
     @property
-    def max_mireds(self) -> int:
-        """Return minimum supported color temperature."""
-        return 500
+    def max_color_temp_kelvin(self) -> int:
+        """Return maximum supported color temperature."""
+        return 7000
 
     @property
-    def min_mireds(self) -> int:
-        """Return maximum supported color temperature."""
-        return 200
+    def min_color_temp_kelvin(self) -> int:
+        """Return minimum supported color temperature."""
+        return 2000
 
     async def turn_on(self, attr_rgb, attr_br, attr_ct) -> None:
         """Turn on the light."""
@@ -416,9 +416,17 @@ class CyncRoom:
             elif attr_rgb is not None and attr_br is None:
                 self.hub.combo_control(True, self.brightness, 254, attr_rgb, controller, self.mesh_id, seq)
             elif attr_ct is not None:
-                ct = round(100*(self.max_mireds - attr_ct)/(self.max_mireds - self.min_mireds))
                 self.hub.turn_on(controller, self.mesh_id, seq)
-                self.hub.set_color_temp(ct, controller, self.mesh_id, seq)
+                # Sync wants the color temp as a percentage of the range. So we need to
+                # calculate what percentage of the color temp range is being requested
+                # before sending it to the server.
+                color_temp = round(
+                    (
+                        (attr_ct - self.min_color_temp_kelvin) /
+                        self.max_color_temp_kelvin
+                    ) * 100
+                )
+                self.hub.set_color_temp(color_temp, controller, self.mesh_id, seq)
             else:
                 self.hub.turn_on(controller, self.mesh_id, seq)
             self.hub.pending_commands[seq] = self.command_received
@@ -456,7 +464,7 @@ class CyncRoom:
     def update_room(self):
         """Update the current state of the room"""
         _brightness = self.brightness
-        _color_temp = self.color_temp
+        _color_temp = self.color_temp_kelvin
         _rgb = self.rgb
         _power_state = True in ([self.hub.cync_switches[device_id].power_state for device_id in self.switches] + [self.hub.cync_rooms[room_id].power_state for room_id in self.subgroups])
         if self.support_brightness:
@@ -464,17 +472,16 @@ class CyncRoom:
         else:
             _brightness = 100 if _power_state else 0
         if self.support_color_temp:
-            _color_temp = round(sum([self.hub.cync_switches[device_id].color_temp for device_id in self.switches_support_color_temp] + [self.hub.cync_rooms[room_id].color_temp for room_id in self.groups_support_color_temp])/(len(self.switches_support_color_temp) + len(self.groups_support_color_temp)))
+            _color_temp = round(sum([self.hub.cync_switches[device_id].color_temp_kelvin for device_id in self.switches_support_color_temp] + [self.hub.cync_rooms[room_id].color_temp_kelvin for room_id in self.groups_support_color_temp])/(len(self.switches_support_color_temp) + len(self.groups_support_color_temp)))
         if self.support_rgb:
             _rgb['r'] = round(sum([self.hub.cync_switches[device_id].rgb['r'] for device_id in self.switches_support_rgb] + [self.hub.cync_rooms[room_id].rgb['r'] for room_id in self.groups_support_rgb])/(len(self.switches_support_rgb) + len(self.groups_support_rgb)))
             _rgb['g'] = round(sum([self.hub.cync_switches[device_id].rgb['g'] for device_id in self.switches_support_rgb] + [self.hub.cync_rooms[room_id].rgb['g'] for room_id in self.groups_support_rgb])/(len(self.switches_support_rgb) + len(self.groups_support_rgb)))
             _rgb['b'] = round(sum([self.hub.cync_switches[device_id].rgb['b'] for device_id in self.switches_support_rgb] + [self.hub.cync_rooms[room_id].rgb['b'] for room_id in self.groups_support_rgb])/(len(self.switches_support_rgb) + len(self.groups_support_rgb)))
             _rgb['active'] = True in ([self.hub.cync_switches[device_id].rgb['active'] for device_id in self.switches_support_rgb] + [self.hub.cync_rooms[room_id].rgb['active'] for room_id in self.groups_support_rgb])
-        
-        if _power_state != self.power_state or _brightness != self.brightness or _color_temp != self.color_temp or _rgb != self.rgb:
+        if _power_state != self.power_state or _brightness != self.brightness or _color_temp != self.color_temp_kelvin or _rgb != self.rgb:
             self.power_state = _power_state
             self.brightness = _brightness
-            self.color_temp = _color_temp
+            self.color_temp_kelvin = _color_temp
             self.rgb = _rgb
             self.publish_update()
             if self._update_parent_room:
@@ -511,7 +518,7 @@ class CyncSwitch:
         self.room = room
         self.power_state = False
         self.brightness = 0
-        self.color_temp = 0
+        self.color_temp_kelvin = 0
         self.rgb = {'r':0, 'g':0, 'b':0, 'active':False}
         self.default_controller = switch_info.get('switch_controller',self.hub.home_controllers[self.home_id][0])
         self.controllers = []
@@ -538,14 +545,14 @@ class CyncSwitch:
         self._update_parent_room = parent_updater
 
     @property
-    def max_mireds(self) -> int:
-        """Return minimum supported color temperature."""
-        return 500
+    def max_color_temp_kelvin(self) -> int:
+        """Return maximum supported color temperature."""
+        return 7000
 
     @property
-    def min_mireds(self) -> int:
-        """Return maximum supported color temperature."""
-        return 200
+    def min_color_temp_kelvin(self) -> int:
+        """Return minimum supported color temperature."""
+        return 2000
 
     async def turn_on(self, attr_rgb, attr_br, attr_ct) -> None:
         """Turn on the light."""
@@ -567,8 +574,16 @@ class CyncSwitch:
             elif attr_rgb is not None and attr_br is None:
                 self.hub.combo_control(True, self.brightness, 254, attr_rgb, controller, self.mesh_id, seq)
             elif attr_ct is not None:
-                ct = round(100*(self.max_mireds - attr_ct)/(self.max_mireds - self.min_mireds))
-                self.hub.set_color_temp(ct, controller, self.mesh_id, seq)
+                # Sync wants the color temp as a percentage of the range. So we need to
+                # calculate what percentage of the color temp range is being requested
+                # before sending it to the server.
+                color_temp = round(
+                    (
+                        (attr_ct - self.min_color_temp_kelvin) /
+                        self.max_color_temp_kelvin
+                    ) * 100
+                )
+                self.hub.set_color_temp(color_temp, controller, self.mesh_id, seq)
             else:
                 self.hub.turn_on(controller, self.mesh_id, seq)
             self.hub.pending_commands[seq] = self.command_received
@@ -606,10 +621,21 @@ class CyncSwitch:
     def update_switch(self,state,brightness,color_temp,rgb):
         """Update the state of the switch as updates are received from the Cync server"""
         self.update_received = True
-        if self.power_state != state or self.brightness != brightness or self.color_temp != color_temp or self.rgb != rgb:
+        # Cync sends the color temp as a percentage from 0-100 based on the max and min
+        # color temp. Most Cync bulbs support 2000K-7000K, so we have to calculate what
+        # is actually being requested.
+        _color_temp = round(
+            (self.max_color_temp_kelvin - self.min_color_temp_kelvin) *
+            (color_temp / 100) +
+            self.min_color_temp_kelvin
+        )
+        if self.power_state != state or self.brightness != brightness or self.color_temp_kelvin != _color_temp or self.rgb != rgb:
             self.power_state = state
             self.brightness = brightness if self.support_brightness and state else 100 if state else 0
-            self.color_temp = color_temp 
+            # Cync sends the color temp as a percentage from 0-100 based on the max and
+            # min color temp. Most Cync bulbs support 2000K-7000K, so we have to
+            # calculate what is actually being requested.
+            self.color_temp_kelvin = _color_temp
             self.rgb = rgb
             self.publish_update()
             if self._update_parent_room:
@@ -621,7 +647,7 @@ class CyncSwitch:
         controllers = []
         if len(connected_devices) > 0:
             if int(self.switch_id) > 0:
-                if self.device_id in connected_devices: 
+                if self.device_id in connected_devices:
                     #if this device is connected, make this the first available controller
                     controllers.append(self.switch_id)
             if self.room:
@@ -641,7 +667,7 @@ class CyncSwitch:
 class CyncMotionSensor:
 
     def __init__(self, device_id, device_info, room):
-        
+
         self.device_id = device_id
         self.name = device_info['name']
         self.home_name = device_info['home_name']
@@ -668,7 +694,7 @@ class CyncMotionSensor:
 class CyncAmbientLightSensor:
 
     def __init__(self, device_id, device_info, room):
-        
+
         self.device_id = device_id
         self.name = device_info['name']
         self.home_name = device_info['home_name']
@@ -716,7 +742,7 @@ class CyncUserData:
                     request_code_data = {'corp_id': "1007d2ad150c4000", 'email': self.username, 'local_lang': "en-us"}
                     async with aiohttp.ClientSession() as session:
                         async with session.post(API_REQUEST_CODE,json=request_code_data) as resp:
-                            if resp.status == 200:                    
+                            if resp.status == 200:
                                 return {'authorized':False,'two_factor_code_required':True}
                             else:
                                 return {'authorized':False,'two_factor_code_required':False}
@@ -757,18 +783,18 @@ class CyncUserData:
                     home_devices[home_id][current_index] = device_id
                     devices[device_id] = {'name':device['displayName'],
                         'mesh_id':current_index,
-                        'switch_id':str(device.get('switchID',0)), 
-                        'ONOFF': device_type in Capabilities['ONOFF'], 
-                        'BRIGHTNESS': device_type in Capabilities["BRIGHTNESS"], 
-                        "COLORTEMP":device_type in Capabilities["COLORTEMP"], 
-                        "RGB": device_type in Capabilities["RGB"], 
-                        "MOTION": device_type in Capabilities["MOTION"], 
-                        "AMBIENT_LIGHT": device_type in Capabilities["AMBIENT_LIGHT"], 
+                        'switch_id':str(device.get('switchID',0)),
+                        'ONOFF': device_type in Capabilities['ONOFF'],
+                        'BRIGHTNESS': device_type in Capabilities["BRIGHTNESS"],
+                        "COLORTEMP":device_type in Capabilities["COLORTEMP"],
+                        "RGB": device_type in Capabilities["RGB"],
+                        "MOTION": device_type in Capabilities["MOTION"],
+                        "AMBIENT_LIGHT": device_type in Capabilities["AMBIENT_LIGHT"],
                         "WIFICONTROL": device_type in Capabilities["WIFICONTROL"],
                         "PLUG" : device_type in Capabilities["PLUG"],
                         "FAN" : device_type in Capabilities["FAN"],
-                        'home_name':home['name'], 
-                        'room':'', 
+                        'home_name':home['name'],
+                        'room':'',
                         'room_name':''
                     }
                     if str(device_type) in Capabilities['MULTIELEMENT'] and current_index < 256:
@@ -798,9 +824,9 @@ class CyncUserData:
                                 if 'switch_controller' not in devices[home_devices[home_id][id]] and devices[home_devices[home_id][id]].get('ONOFF',False):
                                     devices[home_devices[home_id][id]]['switch_controller'] = room_controller
                             rooms[room_id] = {'name':room['displayName'],
-                                'mesh_id' : room['groupID'], 
+                                'mesh_id' : room['groupID'],
                                 'room_controller' : room_controller,
-                                'home_name' : home['name'], 
+                                'home_name' : home['name'],
                                 'switches' : [home_devices[home_id][(i%1000)+(int(i/1000)*256)] for i in room.get('deviceIDArray',[]) if devices[home_devices[home_id][(i%1000)+(int(i/1000)*256)]].get('ONOFF',False)],
                                 'isSubgroup' : room.get('isSubgroup',False),
                                 'subgroups' : [home_id + '-' + str(subgroup) for subgroup in room.get('subgroupIDArray',[])]
@@ -812,7 +838,7 @@ class CyncUserData:
                                     rooms[subgroup]["parent_room"] = room_info["name"]
                                 else:
                                     room_info['subgroups'].pop(room_info['subgroups'].index(subgroup))
-                                    
+
         if len(rooms) == 0 or len(devices) == 0 or len(home_controllers) == 0 or len(home_devices) == 0 or len(switchID_to_homeID) == 0:
             raise InvalidCyncConfiguration
         else:

--- a/custom_components/cync_lights/light.py
+++ b/custom_components/cync_lights/light.py
@@ -1,7 +1,7 @@
 """Platform for light integration."""
 from __future__ import annotations
 from typing import Any
-from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_RGB_COLOR, ColorMode, LightEntity)
+from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_COLOR_TEMP_KELVIN, ATTR_RGB_COLOR, ColorMode, LightEntity)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -88,19 +88,19 @@ class CyncRoomEntity(LightEntity):
         return round(self.room.brightness*255/100)
 
     @property
-    def max_mireds(self) -> int:
-        """Return minimum supported color temperature."""
-        return self.room.max_mireds
-
-    @property
-    def min_mireds(self) -> int:
+    def max_color_temp_kelvin(self) -> int:
         """Return maximum supported color temperature."""
-        return self.room.min_mireds
+        return self.room.max_color_temp_kelvin
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the color temperature of this light in mireds for HA."""
-        return self.max_mireds - round((self.max_mireds-self.min_mireds)*self.room.color_temp/100)
+    def min_color_temp_kelvin(self) -> int:
+        """Return minimum supported color temperature."""
+        return self.room.min_color_temp_kelvin
+
+    @property
+    def color_temp_kelvin(self) -> int:
+        """Return color temperature in kelvin."""
+        return self.room.color_temp_kelvin
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
@@ -121,7 +121,7 @@ class CyncRoomEntity(LightEntity):
             modes.add(ColorMode.BRIGHTNESS)
         if not modes:
             modes.add(ColorMode.ONOFF)
-            
+
         return modes
 
     @property
@@ -136,11 +136,11 @@ class CyncRoomEntity(LightEntity):
         if self.room.support_brightness:
             return ColorMode.BRIGHTNESS
         else:
-            return ColorMode.ONOFF 
+            return ColorMode.ONOFF
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
-        await self.room.turn_on(kwargs.get(ATTR_RGB_COLOR),kwargs.get(ATTR_BRIGHTNESS),kwargs.get(ATTR_COLOR_TEMP))
+        await self.room.turn_on(kwargs.get(ATTR_RGB_COLOR),kwargs.get(ATTR_BRIGHTNESS),kwargs.get(ATTR_COLOR_TEMP_KELVIN))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
@@ -176,7 +176,7 @@ class CyncSwitchEntity(LightEntity):
     @property
     def unique_id(self) -> str:
         """Return Unique ID string."""
-        return 'cync_switch_' + self.cync_switch.device_id 
+        return 'cync_switch_' + self.cync_switch.device_id
 
     @property
     def name(self) -> str:
@@ -194,19 +194,19 @@ class CyncSwitchEntity(LightEntity):
         return round(self.cync_switch.brightness*255/100)
 
     @property
-    def max_mireds(self) -> int:
-        """Return minimum supported color temperature."""
-        return self.cync_switch.max_mireds
-
-    @property
-    def min_mireds(self) -> int:
+    def max_color_temp_kelvin(self) -> int:
         """Return maximum supported color temperature."""
-        return self.cync_switch.min_mireds
+        return self.cync_switch.max_color_temp_kelvin
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the color temperature of this light in mireds for HA."""
-        return self.max_mireds - round((self.max_mireds-self.min_mireds)*self.cync_switch.color_temp/100)
+    def min_color_temp_kelvin(self) -> int:
+        """Return minimum supported color temperature."""
+        return self.cync_switch.min_color_temp_kelvin
+
+    @property
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature of this light for HA."""
+        return self.cync_switch.color_temp_kelvin
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
@@ -242,11 +242,11 @@ class CyncSwitchEntity(LightEntity):
         if self.cync_switch.support_brightness:
             return ColorMode.BRIGHTNESS
         else:
-            return ColorMode.ONOFF 
+            return ColorMode.ONOFF
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
-        await self.cync_switch.turn_on(kwargs.get(ATTR_RGB_COLOR),kwargs.get(ATTR_BRIGHTNESS),kwargs.get(ATTR_COLOR_TEMP))
+        await self.cync_switch.turn_on(kwargs.get(ATTR_RGB_COLOR),kwargs.get(ATTR_BRIGHTNESS),kwargs.get(ATTR_COLOR_TEMP_KELVIN))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""


### PR DESCRIPTION
Mireds and color_temp are being deprecated in 2025. This updates the integration to use kelvins as a percentage of the bulbs' supported temperature range.

- Updates lights to use kelvin instead of mireds for color temp.
- Updates light temp limits to the Cync bulb lineup color temperate limits of 2k-7k