### PR TITLE
Packet parsing reliability improvements

### DIFF
--- a/custom_components/cync_lights/cync_hub.py
+++ b/custom_components/cync_lights/cync_hub.py
@@ -162,7 +162,10 @@ class CyncHub:
                                 switch_id = str(struct.unpack(">I", packet[0:4])[0])
                                 home_id = self.switchID_to_homeID[switch_id]
                                 self._add_connected_devices(switch_id, home_id)
-                                packet = packet[23:]
+                                
+                                inner_frame = packet[7:]
+                                inner_frame = inner_frame.replace(b"\x7d\x5e", b"\x7e")
+                                packet = inner_frame[15:]
                                 while len(packet) > 24:
                                     deviceID = self.home_devices[home_id][int(packet[0])]
                                     if deviceID in self.cync_switches:
@@ -204,7 +207,7 @@ class CyncHub:
                             if switch_id in self.switchID_to_homeID:
                                 home_id = self.switchID_to_homeID[switch_id]
                                 packet = packet[7:]
-                                while packet:
+                                while len(packet) > 3:
                                     datapoint_id = packet[0]
                                     datapoint_length = struct.unpack(">H", packet[1:3])[0] & 0xFFF
                                     if int(packet[3]) < len(self.home_devices[home_id]):


### PR DESCRIPTION
Hey there, I was planning on tackling thermostat integration for this component as I'd love to have my GE thermostat in HA.

I found some bugs in the component related to just the presence of a thermostat on my mesh. I thought I'd make a PR to address some of these before I start on any actual thermostat changes.

- Increased TCP read buffer size to 1500 bytes. Thermostat and sensor data is sent as JSON in the packet, and can exceed 1000 bytes. This would cause other incorrectly offset packets later on.
- Moved the offset in the initial state packet right by one. It was always reading zero, instead of the proper mesh ID. This caused device states not to be accurately reflected on restart of HA
- Add check to ensure switch ID exists in the HA setup, as the thermostat ID was being received in packets and causing a KeyError when looking it up.
- In datapoint packets, the size of each chunk of the packet is defined by the 12 least significant bits of bytes 2-3 of the chunk, updated the loop to utilize this size instead of the hard coded 19 bytes
- Added packet type 0xA8 to acceptable types for "probe" responses
- Fix room update

Thanks, and feel free to let me know if there are questions.